### PR TITLE
Fixed sprite tiling error on uneven sheets #1

### DIFF
--- a/sprite_sheet_splitter.py
+++ b/sprite_sheet_splitter.py
@@ -90,22 +90,22 @@ def get_image_section(image, position, size):
     
     return cropped_img
 
-def split_sprite_sheet(image, size, padding = (0,0)):
-
+def split_sprite_sheet(image, size, padding=(0, 0)):
     sprite_width, sprite_height = size
     padding_x, padding_y = padding
 
     images = []
 
-    image_index = 0
-    for y in range(0, image.size[0] - sprite_width + 1, sprite_width + padding_x):
-        for x in range(0, image.size[1] - sprite_height + 1, sprite_height + padding_y):
-            image_index += 1
+    image_width, image_height = image.size
 
-            cropped_img = get_image_section(image, (x,y), size)
+    for y in range(0, image_height - sprite_height + 1, sprite_height + padding_y):
+        for x in range(0, image_width - sprite_width + 1, sprite_width + padding_x):
+            box = (x, y, x + sprite_width, y + sprite_height)
+            cropped_img = image.crop(box)
             images.append(cropped_img)
-    
+
     return images
+
 
 def image_is_blank(image):
     """

--- a/tests/test_sheet_split.py
+++ b/tests/test_sheet_split.py
@@ -4,6 +4,7 @@ tests for the sprite sheet splitter
 import unittest
 import pathlib
 from PIL import Image
+from PIL.Image import Transpose
 import sys
 import os
 
@@ -69,6 +70,14 @@ class TestSpriteSheetSplitter(unittest.TestCase):
         test_existance(path)
         self.sprite_sheet_2x2_padded = Image.open(path)
 
+        path = data_directory.joinpath("4x1_sprite_sheet.png")
+        test_existance(path)
+        self.sprite_sheet_4x1 = Image.open(path)
+
+        path = data_directory.joinpath("4x1_sprite_sheet_padded_10.png")
+        test_existance(path)
+        self.sprite_sheet_4x1_padded = Image.open(path)
+
         sprites = []
         for i in range(1,5):
             path = data_directory.joinpath(f"sprite_entry_{i}.png")
@@ -132,8 +141,8 @@ class TestSpriteSheetSplitter(unittest.TestCase):
         padding = (20, 20)
 
         split_images = sprite_sheet_splitter.split_sprite_sheet(sheet, sprite_size, padding)
-        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split1 (Did not result in four images.)")
-        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split1 (Image size mismatch.)")
+        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split2 (Did not result in four images.)")
+        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split2 (Image size mismatch.)")
 
         for i in range(4):
             self.assertTrue(
@@ -145,6 +154,86 @@ class TestSpriteSheetSplitter(unittest.TestCase):
             )
 
 
+    def test_sprite_sheet_split3(self):
+        """
+        test checking if image can be split properly. This time with a 4x1 sprite sheet.
+        """
+        sheet = self.sprite_sheet_4x1.convert("RGBA")
+        sprite_size = (50,50)
+        padding = (0,0)
 
+        split_images = sprite_sheet_splitter.split_sprite_sheet(sheet, sprite_size, padding)
+        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split3 (Did not result in four images.)")
+        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split3 (Image size does not match requirement.)")
 
-        
+        for i in range(4):
+            self.assertTrue(
+                images_are_equal(
+                    split_images[i].convert("RGBA"),
+                    self.sprites[i].convert("RGBA")
+                ),
+            msg="sprite_sheet_split.test_sprite_sheet_split3 (Images are not equal.)"
+            )
+
+    def test_sprite_sheet_split4(self):
+        """
+        test checking if image can be split properly. This time with a 4x1 sprite sheet, but with padding.
+        """
+        sheet = self.sprite_sheet_4x1_padded.convert("RGBA")
+        sprite_size = (50,50)
+        padding = (10,10)
+
+        split_images = sprite_sheet_splitter.split_sprite_sheet(sheet, sprite_size, padding)
+        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split4 (Did not result in four images.)")
+        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split4 (Image size does not match requirement.)")
+
+        for i in range(4):
+            self.assertTrue(
+                images_are_equal(
+                    split_images[i].convert("RGBA"),
+                    self.sprites[i].convert("RGBA")
+                ),
+            msg="sprite_sheet_split.test_sprite_sheet_split4 (Images are not equal.)"
+            )
+
+    def test_sprite_sheet_split5(self):
+        """
+        test checking if image can be split properly. This time with a 1x4 sprite sheet.
+        """
+        sheet = self.sprite_sheet_4x1.transpose(Transpose.TRANSPOSE).convert("RGBA")
+        sprite_size = (50,50)
+        padding = (0,0)
+
+        split_images = sprite_sheet_splitter.split_sprite_sheet(sheet, sprite_size, padding)
+        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split5 (Did not result in four images.)")
+        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split5 (Image size does not match requirement.)")
+
+        for i in range(4):
+            self.assertTrue(
+                images_are_equal(
+                    split_images[i].convert("RGBA"),
+                    self.sprites[i].convert("RGBA")
+                ),
+            msg="sprite_sheet_split.test_sprite_sheet_split5 (Images are not equal.)"
+            )
+
+    def test_sprite_sheet_split6(self):
+        """
+        test checking if image can be split properly. This time with a 1x4 sprite sheet, but with padding.
+        """
+        sheet = self.sprite_sheet_4x1_padded.transpose(Transpose.TRANSPOSE).convert("RGBA")
+        sprite_size = (50,50)
+        padding = (10,10)
+
+        split_images = sprite_sheet_splitter.split_sprite_sheet(sheet, sprite_size, padding)
+        self.assertEqual(len(split_images), 4, msg="sprite_sheet_split.test_sprite_sheet_split6 (Did not result in four images.)")
+        self.assertTrue(sprite_size == split_images[0].size, msg="sprite_sheet_split.test_sprite_sheet_split6 (Image size does not match requirement.)")
+
+        for i in range(4):
+            self.assertTrue(
+                images_are_equal(
+                    split_images[i].convert("RGBA"),
+                    self.sprites[i].convert("RGBA")
+                ),
+            msg="sprite_sheet_split.test_sprite_sheet_split6 (Images are not equal.)"
+            )

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -15,6 +15,10 @@ def make_suite():
     suite.addTest(TestSpriteSheetSplitter('test_blank_check2'))
     suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split1'))
     suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split2'))
+    suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split3'))
+    suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split4'))
+    suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split5'))
+    suite.addTest(TestSpriteSheetSplitter('test_sprite_sheet_split6'))
 
     suite.addTest(TestSpriteSheetGenerator('test_sprite_sheet_gen1'))
     suite.addTest(TestSpriteSheetGenerator('test_sprite_sheet_gen2'))


### PR DESCRIPTION
Resolved problem where non-even sheets resulted in inaccurate splits by the splitter. #1 

Added 4 new tests to account for uneven sprite sheets. These tests account for multiple edge cases:
- 4x1
- 4x1 padded
- 1x4
- 1x4 padded